### PR TITLE
Fix Issue#3: Timer1,3,5 don't work with 20 ms period

### DIFF
--- a/bio-arm/boards/app.overlay
+++ b/bio-arm/boards/app.overlay
@@ -2,26 +2,26 @@
 	pwmmotors {
 		compatible = "pwm-motors";
 		pwm_motor_1: pwm_1 {
-			pwms = <&pwm1 3 PWM_USEC(500) (PWM_POLARITY_NORMAL)>;
-			min-pulse = <PWM_USEC(5)>;
-			max-pulse = <PWM_USEC(295)>;
+			pwms = <&pwm1 2 PWM_MSEC(20) (PWM_POLARITY_NORMAL)>;
+			min-pulse = <PWM_USEC(11200)>;
+			max-pulse = <PWM_USEC(19200)>;
 		};
 		pwm_motor_2: pwm_2 {
-			pwms = <&pwm2 1 PWM_USEC(500) (PWM_POLARITY_NORMAL)>;
-			min-pulse = <PWM_USEC(5)>;
-			max-pulse = <PWM_USEC(295)>;
+			pwms = <&pwm2 1 PWM_MSEC(20) (PWM_POLARITY_NORMAL)>;
+			min-pulse = <PWM_USEC(11200)>;
+			max-pulse = <PWM_USEC(19200)>;
 		};
 
 		pwm_servo_1: pwm_3 {
-			pwms = <&pwm3 2 PWM_USEC(500) (PWM_POLARITY_NORMAL)>;
-			min-pulse = <PWM_NSEC(5)>;
-			max-pulse = <PWM_NSEC(295)>;
+			pwms = <&pwm3 2 PWM_MSEC(20) (PWM_POLARITY_NORMAL)>;
+			min-pulse = <PWM_USEC(11200)>;
+			max-pulse = <PWM_USEC(19200)>;
 		};
 
 		pwm_servo_2: pwm_4 {
-			pwms = <&pwm4 3 PWM_USEC(500) (PWM_POLARITY_NORMAL)>;
-			min-pulse = <PWM_USEC(5)>;
-			max-pulse = <PWM_USEC(295)>;
+			pwms = <&pwm4 3 PWM_MSEC(20) (PWM_POLARITY_NORMAL)>;
+			min-pulse = <PWM_USEC(11200)>;
+			max-pulse = <PWM_USEC(19200)>;
 		};
 	};
 
@@ -42,18 +42,27 @@
 
 };
 
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pb6 &usart1_rx_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+	current-speed = <115200>;
+};
+
 &timers1 {
 	status = "okay";
+	st,prescaler = <1679>;
 
 	pwm1: pwm {
 		status = "okay";
-		pinctrl-0 = <&tim1_ch3n_pb15>; 
+		pinctrl-0 = <&tim1_ch2_pa9>; 
 		pinctrl-names = "default";
 	};	
 };
 
 &timers2 {
 	status = "okay";
+	st,prescaler = <1679>;
 
 	pwm2: pwm {
 		status = "okay";
@@ -64,6 +73,7 @@
 
 &timers3 {
 	status = "okay";
+	st,prescaler = <1679>;
 
 	pwm3: pwm {
 		status = "okay";
@@ -74,6 +84,7 @@
 
 &timers4 {
 	status = "okay";
+	st,prescaler = <1679>;
 
 	pwm4: pwm {
 		status = "okay";

--- a/bio-arm/src/main.c
+++ b/bio-arm/src/main.c
@@ -117,7 +117,7 @@ int main(void)
 	int err;
 	uint32_t count = 0;
 	uint16_t buf;
-	uint32_t pulse = 150000;
+	uint32_t pulse = 15200000;
 	enum direction dir = UP;
 	struct adc_sequence sequence = {
 		.buffer = &buf,
@@ -209,9 +209,9 @@ int main(void)
 				return 0;
 			}
 
-			pulse += 29000;
+			pulse += 1000000 ;
 
-			if (pulse >= 295000)
+			if (pulse >= 19200000)
 				dir = DOWN;
 			gpio_pin_toggle_dt(&led);
 			k_sleep(K_SECONDS(1));
@@ -229,9 +229,9 @@ int main(void)
 				return 0;
 			}
 
-			pulse -= 29000;
+			pulse -= 1000000;
 
-			if (pulse <= 5000)
+			if (pulse <= 11200000)
 				dir = UP;
 			gpio_pin_toggle_dt(&led);
 			k_sleep(K_SECONDS(1));


### PR DESCRIPTION
Issue #3 was addressed.
Timer 1 was not working because it was set to use complimentary channel.
Timer 1, 3 , 5 not supporting 20 ms period length because they are 16 bit timers and hence need appropriate prescaler

All timers have been set to use prescaler of 1679
Timer 1 output has been changed to pa9
USART1 has been redirected to pb6 and pb7
pwm duty cycle has been set to oscillate between 56% to 96%