### PR TITLE
Build Kyvernitis as Library

### DIFF
--- a/kyvernitis.h
+++ b/kyvernitis.h
@@ -1,0 +1,7 @@
+/*
+* Kyervnitis helper macros and function declarations
+*/
+
+#define MAX_ROBOCLAWS 2
+#define MAX_SABERTOOTHS 3
+#define MAX_SERVOS 5

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,8 @@
+if(CONFIG_KYVERNITIS)
+    set(KYVERNITIS_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
+    zephyr_include_directories(${KYVERNITIS_DIR})
+    zephyr_library()
+    zephyr_library_sources(
+        ${KYVERNITIS_DIR}/kyvernitis.c
+        )
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,4 @@
+config KYVERNITIS
+	bool "Enable kyvernitis"
+	help
+	  This option enables kyvernitis as a Zephyr module.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,7 @@
+name: Kyvernitis
+
 build:
+  cmake: zephyr/
+  kconfig: zephyr/Kconfig
   settings:
     dts_root: .


### PR DESCRIPTION
This PR includes changes which will build **kyvernitis** as a library. This is in consideration of keeping helper functions and macros in a separate place to avoid repetition over different applications.