### PR TITLE
Changed zephyr_library_sources to work with non-stm boards 

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -6,7 +6,10 @@ if(CONFIG_KYVERNITIS)
         ${KYVERNITIS_DIR}/lib/kyvernitis.c
         ${KYVERNITIS_DIR}/lib/drive.c
         ${KYVERNITIS_DIR}/lib/joint_control.c
-        ${KYVERNITIS_DIR}/drivers/sensor/wheel_encoders_stm32/qdec_distance_stm32.c
         )
+    if(CONFIG_SOC_FAMILY_STM32)
+       zephyr_library_sources(
+           ${KYVERNITIS_DIR}/drivers/sensor/wheel_encoders_stm32/qdec_distance_stm32.c
+      )
     # add_subdirectory(${KYVERNITIS_DIR}/drivers build)
 endif()


### PR DESCRIPTION
Changed zephyr_library_sources to work with non-stm boards  without errors. 
Tested with rpi_pico. stm32 error from wheel encoders were coming. 
Tested building with both stm and non-stm board codes.